### PR TITLE
add argument for reliably checking the started X server is our own

### DIFF
--- a/pyvirtualdisplay/abstractdisplay.py
+++ b/pyvirtualdisplay/abstractdisplay.py
@@ -144,7 +144,7 @@ class AbstractDisplay(EasyProcess):
 
         d = self.new_display_var
         ok = False
-        while time.time() - start_time < X_START_TIMEOUT:
+        while True:
             try:
                 exit_code = EasyProcess('xdpyinfo').call().return_code
             except EasyProcessError:
@@ -160,6 +160,8 @@ class AbstractDisplay(EasyProcess):
                 ok = True
                 break
 
+            if time.time() - start_time >= X_START_TIMEOUT:
+                break
             time.sleep(X_START_TIME_STEP)
         if not ok:
             msg = 'Failed to start X on display "%s" (xdpyinfo check failed).'

--- a/pyvirtualdisplay/display.py
+++ b/pyvirtualdisplay/display.py
@@ -57,5 +57,6 @@ class Display(AbstractDisplay):
     def _cmd(self):
         self._obj.display = self.display
         self._obj.check_startup = self.check_startup
-        self._obj.check_startup_fd = self.check_startup_fd
+        if self.check_startup:
+            self._obj.check_startup_fd = self.check_startup_fd
         return self._obj._cmd

--- a/pyvirtualdisplay/display.py
+++ b/pyvirtualdisplay/display.py
@@ -15,7 +15,7 @@ class Display(AbstractDisplay):
     :param backend: 'xvfb', 'xvnc' or 'xephyr', ignores ``visible``
     :param xauth: If a Xauthority file should be created.
     '''
-    def __init__(self, backend=None, visible=False, size=(1024, 768), color_depth=24, bgcolor='black', use_xauth=False, **kwargs):
+    def __init__(self, backend=None, visible=False, size=(1024, 768), color_depth=24, bgcolor='black', use_xauth=False, check_startup=False, **kwargs):
         self.color_depth = color_depth
         self.size = size
         self.bgcolor = bgcolor
@@ -36,7 +36,7 @@ class Display(AbstractDisplay):
             color_depth=color_depth,
             bgcolor=bgcolor,
             **kwargs)
-        AbstractDisplay.__init__(self, use_xauth=use_xauth)
+        AbstractDisplay.__init__(self, use_xauth=use_xauth, check_startup=check_startup)
 
     @property
     def display_class(self):
@@ -56,4 +56,6 @@ class Display(AbstractDisplay):
     @property
     def _cmd(self):
         self._obj.display = self.display
+        self._obj.check_startup = self.check_startup
+        self._obj.check_startup_fd = self.check_startup_fd
         return self._obj._cmd

--- a/pyvirtualdisplay/xephyr.py
+++ b/pyvirtualdisplay/xephyr.py
@@ -38,4 +38,6 @@ class XephyrDisplay(AbstractDisplay):
                '-resizeable',
                self.new_display_var,
                ]
+        if self.check_startup:
+            cmd += ['-displayfd', str(self.check_startup_fd)]
         return cmd

--- a/pyvirtualdisplay/xvfb.py
+++ b/pyvirtualdisplay/xvfb.py
@@ -50,4 +50,6 @@ class XvfbDisplay(AbstractDisplay):
                ]
         if self.fbdir:
             cmd += ['-fbdir', self.fbdir]
+        if self.check_startup:
+            cmd += ['-displayfd', str(self.check_startup_fd)]
         return [PROGRAM] + cmd

--- a/pyvirtualdisplay/xvnc.py
+++ b/pyvirtualdisplay/xvnc.py
@@ -40,4 +40,6 @@ class XvncDisplay(AbstractDisplay):
                '-rfbport', str(self.rfbport),
                self.new_display_var,
                ]
+        if self.check_startup:
+            cmd += ['-displayfd', str(self.check_startup_fd)]
         return cmd


### PR DESCRIPTION
- needed to avoid race conditions when multiple scripts start a X server simultaniously
- currently the python 3 implementation is possibly incomplete as the EasyProcess module currently does not provide a way to inherit the needed fd on pathon >= 3.2